### PR TITLE
Fix max player level bug

### DIFF
--- a/lbforaging/__init__.py
+++ b/lbforaging/__init__.py
@@ -13,7 +13,7 @@ for s, p, f, c, po in product(sizes, players, foods, coop, partial_obs):
         entry_point="lbforaging.foraging:ForagingEnv",
         kwargs={
             "players": p,
-            "max_player_level": 3,
+            "max_player_level": 2,
             "field_size": (s, s),
             "max_food": f,
             "sight": 2 if po else s,
@@ -31,7 +31,7 @@ def grid_registration():
                 entry_point="lbforaging.foraging:ForagingEnv",
                 kwargs={
                     "players": p,
-                    "max_player_level": 3,
+                    "max_player_level": 2,
                     "field_size": (s, s),
                     "max_food": f,
                     "sight": sight,

--- a/lbforaging/foraging/environment.py
+++ b/lbforaging/foraging/environment.py
@@ -267,6 +267,8 @@ class ForagingEnv(Env):
             self.field[row, col] = (
                 min_level
                 if min_level == max_level
+                # ! this is excluding food of level `max_level` but is kept for
+                # ! consistency with prior LBF versions
                 else self.np_random.randint(min_level, max_level)
             )
             food_count += 1
@@ -293,7 +295,7 @@ class ForagingEnv(Env):
                 if self._is_empty_location(row, col):
                     player.setup(
                         (row, col),
-                        self.np_random.randint(1, max_player_level),
+                        self.np_random.randint(1, max_player_level + 1),
                         self.field_size,
                     )
                     break


### PR DESCRIPTION
- bug prevented players of level `max_player_level`
- to maintain consistency with prior LBF versions, the default `max_player_level` is reduced by 1 --> players are still spawned with same level distribution as in prior versions
- same bug in food levels which affects all levels without `force_coop=True` but for consistency with prior LBF versions this is not changed