### PR TITLE
Feature/python3dot10 gym compatibility update

### DIFF
--- a/lbforaging.py
+++ b/lbforaging.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import random
 import time
 import gym
 import numpy as np
@@ -13,7 +12,7 @@ logger = logging.getLogger(__name__)
 def _game_loop(env, render):
     """
     """
-    obs = env.reset()
+    _, _ = env.reset()
     done = False
 
     if render:
@@ -24,7 +23,7 @@ def _game_loop(env, render):
 
         actions = env.action_space.sample()
 
-        nobs, nreward, ndone, _ = env.step(actions)
+        _, nreward, ndone, _ = env.step(actions)
         if sum(nreward) > 0:
             print(nreward)
 
@@ -38,9 +37,9 @@ def _game_loop(env, render):
 
 def main(game_count=1, render=False):
     env = gym.make("Foraging-8x8-2p-2f-v2")
-    obs = env.reset()
+    env.reset()
 
-    for episode in range(game_count):
+    for _ in range(game_count):
         _game_loop(env, render)
 
 

--- a/lbforaging.py
+++ b/lbforaging.py
@@ -1,3 +1,4 @@
+'''Basic flow to see if the base install worked over one environment.'''
 import argparse
 import logging
 import time
@@ -53,3 +54,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     main(args.times, args.render)
+
+    print("Done. NO RUNTIME ERRORS.")

--- a/lbforaging/agents/__init__.py
+++ b/lbforaging/agents/__init__.py
@@ -1,5 +1,1 @@
-# from lbforaging.agents.random_agent import RandomAgent
-# from lbforaging.agents.heuristic_agent import H1, H2, H3, H4
-# from lbforaging.agents.q_agent import QAgent
-# from lbforaging.agents.monte_carlo import MonteCarloAgent
-# from lbforaging.agents.hba import HBAAgent
+from lbforaging.agents import *

--- a/lbforaging/agents/hba.py
+++ b/lbforaging/agents/hba.py
@@ -1,8 +1,8 @@
-from . import QAgent
-from foraging import Env
+from lbforaging.agents.q_agent import QAgent
+from lbforaging.foraging.environment import ForagingEnv as Env
 import random
 import numpy as np
-from agents import H1, H2, H3, H4
+from lbforaging.agents.heuristic_agent import H1, H2, H3, H4
 from itertools import product
 from collections import defaultdict
 from functools import reduce

--- a/lbforaging/agents/heuristic_agent.py
+++ b/lbforaging/agents/heuristic_agent.py
@@ -1,7 +1,7 @@
 import random
 import numpy as np
-from foraging import Agent
-from foraging.environment import Action
+from lbforaging.foraging.agent import Agent
+from lbforaging.foraging.environment import Action
 
 
 class HeuristicAgent(Agent):
@@ -28,7 +28,7 @@ class HeuristicAgent(Agent):
             raise ValueError("No simple path found")
 
     def step(self, obs):
-        raise NotImplemented("Heuristic agent is implemented by H1-H4")
+        raise NotImplementedError("Heuristic agent is implemented by H1-H4")
 
 
 class H1(HeuristicAgent):

--- a/lbforaging/agents/monte_carlo.py
+++ b/lbforaging/agents/monte_carlo.py
@@ -8,7 +8,8 @@ import networkx as nx
 import plotly.graph_objs as go
 from networkx.drawing.nx_pydot import graphviz_layout
 
-from foraging import Agent, Env
+from lbforaging.foraging.agent import Agent
+from lbforaging.foraging.environment import ForagingEnv as Env
 
 MCTS_DEPTH = 15
 

--- a/lbforaging/agents/nn_agent.py
+++ b/lbforaging/agents/nn_agent.py
@@ -1,6 +1,6 @@
 import random
 
-from foraging import Agent
+from lbforaging.foraging.agent import Agent
 
 
 class NNAgent(Agent):

--- a/lbforaging/agents/q_agent.py
+++ b/lbforaging/agents/q_agent.py
@@ -4,9 +4,10 @@ from itertools import repeat, product
 import numpy as np
 import pandas as pd
 
-from agents import H1
-from lbforaging import Agent, Env
-from lbforaging.environment import Action
+from lbforaging.agents.heuristic_agent import H1
+from lbforaging.foraging.agent import Agent
+from lbforaging.foraging.environment import Action
+from lbforaging.foraging.environment import ForagingEnv as Env
 
 _CACHE = None
 

--- a/lbforaging/agents/random_agent.py
+++ b/lbforaging/agents/random_agent.py
@@ -1,6 +1,6 @@
 import random
 
-from lbforaging import Agent
+from lbforaging.foraging.agent import Agent
 
 
 class RandomAgent(Agent):

--- a/lbforaging/foraging/agent.py
+++ b/lbforaging/foraging/agent.py
@@ -30,7 +30,7 @@ class Agent:
         return action
 
     def step(self, obs):
-        raise NotImplemented("You must implement an agent")
+        raise NotImplementedError("You must implement an agent")
 
     def _closest_food(self, obs, max_food_level=None, start=None):
 

--- a/lbforaging/foraging/agent.py
+++ b/lbforaging/foraging/agent.py
@@ -1,5 +1,4 @@
 import logging
-
 import numpy as np
 
 _MAX_INT = 999999

--- a/lbforaging/foraging/environment.py
+++ b/lbforaging/foraging/environment.py
@@ -93,7 +93,7 @@ class ForagingEnv(Env):
         self.field = np.zeros(field_size, np.int32)
 
         self.penalty = penalty
-        
+
         self.max_food = max_food
         self._food_spawned = 0.0
         self.max_player_level = max_player_level

--- a/lbforaging/foraging/environment.py
+++ b/lbforaging/foraging/environment.py
@@ -109,13 +109,14 @@ class ForagingEnv(Env):
         self._grid_observation = grid_observation
 
         self.action_space = gym.spaces.Tuple(tuple([gym.spaces.Discrete(6)] * len(self.players)))
-        self.observation_space = gym.spaces.Tuple(tuple([self._get_observation_space()] * len(self.players)))
+        self.observation_space = gym.spaces.Tuple(
+            tuple([self._get_observation_space()] * len(self.players)))
 
         self.viewer = None
 
         self.n_agents = len(self.players)
 
-    def seed(self, seed=None):
+    def seed(self, seed=0):
         self.np_random, seed = seeding.np_random(seed)
         return [seed]
 
@@ -159,7 +160,15 @@ class ForagingEnv(Env):
             min_obs = np.stack([agents_min, foods_min, access_min])
             max_obs = np.stack([agents_max, foods_max, access_max])
 
-        return gym.spaces.Box(np.array(min_obs), np.array(max_obs), dtype=np.float32)
+        low_obs = np.array(min_obs)
+        high_obs = np.array(max_obs)
+        assert len(low_obs) == len(high_obs)
+        composed_obs_space = gym.spaces.Box(
+            low=low_obs,
+            high=high_obs,
+            shape=[len(low_obs)],
+            dtype=np.float32)
+        return composed_obs_space
 
     @classmethod
     def from_obs(cls, obs):
@@ -201,6 +210,14 @@ class ForagingEnv(Env):
             ]
             for player in self.players
         }
+
+    def test_gen_valid_moves(self) -> bool:
+        ''' Wrapper around a private method to test if the generated moves are valid. '''
+        try:
+            self._gen_valid_moves()
+        except Exception as _:
+            return False
+        return True
 
     def neighborhood(self, row, col, distance=1, ignore_diag=False):
         if not ignore_diag:
@@ -253,8 +270,8 @@ class ForagingEnv(Env):
 
         while food_count < max_food and attempts < 1000:
             attempts += 1
-            row = self.np_random.randint(1, self.rows - 1)
-            col = self.np_random.randint(1, self.cols - 1)
+            row = self.np_random.integers(1, self.rows - 1)
+            col = self.np_random.integers(1, self.cols - 1)
 
             # check if it has neighbors:
             if (
@@ -269,7 +286,7 @@ class ForagingEnv(Env):
                 if min_level == max_level
                 # ! this is excluding food of level `max_level` but is kept for
                 # ! consistency with prior LBF versions
-                else self.np_random.randint(min_level, max_level)
+                else self.np_random.integers(min_level, max_level)
             )
             food_count += 1
         self._food_spawned = self.field.sum()
@@ -290,12 +307,12 @@ class ForagingEnv(Env):
             player.reward = 0
 
             while attempts < 1000:
-                row = self.np_random.randint(0, self.rows)
-                col = self.np_random.randint(0, self.cols)
+                row = self.np_random.integers(0, self.rows)
+                col = self.np_random.integers(0, self.cols)
                 if self._is_empty_location(row, col):
                     player.setup(
                         (row, col),
-                        self.np_random.randint(1, max_player_level + 1),
+                        self.np_random.integers(1, max_player_level + 1),
                         self.field_size,
                     )
                     break
@@ -467,6 +484,10 @@ class ForagingEnv(Env):
         
         return nobs, nreward, ndone, ninfo
 
+    def test_make_gym_obs(self):
+        ''' Test wrapper to test the current observation in a public manner. '''
+        return self._make_gym_obs()
+
     def reset(self):
         self.field = np.zeros(self.field_size, np.int32)
         self.spawn_players(self.max_player_level)
@@ -480,7 +501,9 @@ class ForagingEnv(Env):
         self._gen_valid_moves()
 
         nobs, _, _, _ = self._make_gym_obs()
-        return nobs
+        # The new gym spec and gym utils require that
+        # the new observation and a dictionary with info is returned
+        return nobs, {}
 
     def step(self, actions):
         self.current_step += 1

--- a/lbforaging/foraging/rendering.py
+++ b/lbforaging/foraging/rendering.py
@@ -30,6 +30,18 @@ except ImportError as e:
     )
 
 try:
+    from pyglet import gl
+except ImportError as e:
+    raise ImportError(
+        """
+    Cannot 'from pyglet import gl'
+    HINT: you can install pyglet directly via 'pip install pyglet'.
+    But if you really just want to install all Gym dependencies and not have to think about it,
+    'pip install -e .[all]' or 'pip install gym[all]' will do it.
+    """
+    )
+
+try:
     from pyglet.gl import *
 except ImportError as e:
     raise ImportError(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.10",
     ],
-    install_requires=["numpy", "gym==0.26", "pyglet"],
+    install_requires=["numpy", "gym==0.26", "pyglet<2"],
     extras_require={"test": ["pytest"]},
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.10",
     ],
-    install_requires=["numpy", "gym==0.21", "pyglet"],
+    install_requires=["numpy", "gym==0.26", "pyglet"],
     extras_require={"test": ["pytest"]},
     include_package_data=True,
 )

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -11,8 +11,7 @@ def manhattan_distance(x,y):
 @pytest.fixture
 def simple2p1f():
     env = gym.make("Foraging-8x8-2p-1f-v2")
-    _ = env.reset()
-    import time
+    env.reset()
 
     env.field[:] = 0
 
@@ -24,14 +23,13 @@ def simple2p1f():
 
     env.players[0].level = 2
     env.players[1].level = 2
-    env._gen_valid_moves()
+    assert env.test_gen_valid_moves()
     return env
 
 @pytest.fixture
 def simple2p1f_sight1():
     env = gym.make("Foraging-8x8-2p-1f-v2", sight=1)
-    _ = env.reset()
-    import time
+    env.reset()
 
     env.field[:] = 0
 
@@ -43,14 +41,13 @@ def simple2p1f_sight1():
 
     env.players[0].level = 2
     env.players[1].level = 2
-    env._gen_valid_moves()
+    assert env.test_gen_valid_moves()
     return env
 
 @pytest.fixture
 def simple2p1f_sight2():
     env = gym.make("Foraging-8x8-2p-1f-v2", sight=2)
-    _ = env.reset()
-    import time
+    env.reset()
 
     env.field[:] = 0
 
@@ -62,15 +59,20 @@ def simple2p1f_sight2():
 
     env.players[0].level = 2
     env.players[1].level = 2
-    env._gen_valid_moves()
+    assert env.test_gen_valid_moves()
     return env
 
 
 def test_make():
-    env = gym.make("Foraging-8x8-2p-1f-v2")
-    env = gym.make("Foraging-5x5-2p-1f-v2")
-    env = gym.make("Foraging-8x8-3p-1f-v2")
-    env = gym.make("Foraging-8x8-3p-1f-coop-v2")
+    ''' Tests that we can make and reset the environments. '''
+    enames = ["Foraging-8x8-2p-1f-v2",
+              "Foraging-5x5-2p-1f-v2",
+              "Foraging-8x8-3p-1f-v2",
+              "Foraging-8x8-3p-1f-coop-v2"]
+    for ename in enames:
+        env = gym.make(ename)
+        assert env is not None
+        env.reset()
 
 
 def test_spaces():
@@ -83,11 +85,13 @@ def test_seed():
         obs1 = []
         obs2 = []
         env.seed(seed)
-        for r in range(10):
-            obs1.append(env.reset())
+        for _ in range(10):
+            temp_obs, _ = env.reset()
+            obs1.append(temp_obs)
         env.seed(seed)
-        for r in range(10):
-            obs2.append(env.reset())
+        for _ in range(10):
+            temp_obs, _ = env.reset()
+            obs2.append(temp_obs)
 
     for o1, o2 in zip(obs1, obs2):
         assert np.array_equal(o1, o2)
@@ -96,8 +100,8 @@ def test_seed():
 def test_food_spawning_0():
     env = gym.make("Foraging-6x6-2p-2f-v2")
 
-    for i in range(1000):
-        _ = env.reset()
+    for _ in range(1000):
+        env.reset()
 
         foods = [np.array(f) for f in zip(*env.field.nonzero())]
         # we should have 2 foods
@@ -115,8 +119,8 @@ def test_food_spawning_0():
 def test_food_spawning_1():
     env = gym.make("Foraging-8x8-2p-3f-v2")
 
-    for i in range(1000):
-        _ = env.reset()
+    for _ in range(1000):
+        env.reset()
 
         foods = [np.array(f) for f in zip(*env.field.nonzero())]
         # we should have 3 foods
@@ -129,24 +133,24 @@ def test_food_spawning_1():
 
 def test_reward_0(simple2p1f):
     _, rewards, _, _ = simple2p1f.step([5, 5])
-    assert rewards[0] == 0.5
-    assert rewards[1] == 0.5
+    assert rewards[0] == 1.0
+    assert rewards[1] == 1.0
 
 def test_reward_1(simple2p1f):
     _, rewards, _, _ = simple2p1f.step([0, 5])
     assert rewards[0] == 0
-    assert rewards[1] == 1
+    assert rewards[1] == 2.0
 
 def test_partial_obs_1(simple2p1f_sight1):
     env = simple2p1f_sight1
-    obs, _, _, _ = env._make_gym_obs()
+    obs, _, _, _ = env.test_make_gym_obs()
 
     assert obs[0][-2] == -1
     assert obs[1][-2] == -1
 
 def test_partial_obs_2(simple2p1f_sight2):
     env = simple2p1f_sight2
-    obs, _, _, _ = env._make_gym_obs()
+    obs, _, _, _ = env.test_make_gym_obs()
 
     assert obs[0][-2] > -1
     assert obs[1][-2] > -1
@@ -158,7 +162,7 @@ def test_partial_obs_2(simple2p1f_sight2):
 
 def test_partial_obs_3(simple2p1f):
     env = simple2p1f
-    obs, _, _, _ = env._make_gym_obs()
+    obs, _, _, _ = env.test_make_gym_obs()
 
     assert obs[0][-2] > -1
     assert obs[1][-2] > -1


### PR DESCRIPTION
Changes made: 

<ol>
  <li>Python3.10 and Numpy Update</li>
    <ol>
      <li> The repo is now compatible with python 3.10. 
      <li> The syntax/function calls have been updated to work with the newer version of Numpy. For instance, 

`.randint(...)`

was changed to 

`.integer(...)`

  </ol>
  <li>New gym version 0.26</li>
    <ol>
      <li> Gym 0.26 now passively type checks your function outputs at runtime, and some of the return types have changed. Specifically, the reset function now needs to return an observation and a dictionary with any information: 

```env.reset() -> obs, {}``` 

   <li> The return of the reset function has been updated, and the tests have also been updated, so they now pass with this change in place. 
  </ol>
  <li> The repo is not compatible with the newly updated pyglet2.* so the setup file has been changed to specify that the user needs a version of pyglet that is before version 2. 
  <li> Fixed the import and dependencies in the agents directory.
  <li> Now, all tests pass the following is run: 

`python -m pytest test_env.py` 

while in the test directory and all the tests pass. At the highest level of the repo, the following can be run and the environment will be properly rendered. 

`python lbforaging.py --render` 

</ol>